### PR TITLE
Invalid use of ,string struct tag

### DIFF
--- a/config.go
+++ b/config.go
@@ -92,7 +92,7 @@ type Config struct {
 		StripStringMetrics bool   `json:"strip.string.metrics,string"`
 		ConcurrencyLimit   uint32 `json:"post.request.concurrency.limit,string"`
 		ForwardElastic     bool   `json:"api.endpoint.is.elasticsearch,string"`
-		InputFormat        string `json:"input.format,string"`
+		InputFormat        string `json:"input.format"`
 	} `json:"dustdevil"`
 	// Cyclone is the namespace with configuration options relating
 	// to threshold evaluation of metrics


### PR DESCRIPTION
I fixed a small typo in the config struct.

time="2018-12-04T13:15:17.256693186+01:00" level=fatal msg="Could not open configuration: json: invalid use of ,string struct tag, trying to unmarshal \"split\" into string"